### PR TITLE
Revert "img4: fix compiling for linux"

### DIFF
--- a/src/img4.c
+++ b/src/img4.c
@@ -123,8 +123,7 @@ static const unsigned char *asn1_find_element(unsigned int index, unsigned char 
 	}
 
 	// find the element we are searching
-    int i = 0;
-    while (i <= index, i++) {
+	for (int i = 0; i <= index; i++) {
 		off += asn1_get_element(&data[off], &el_type, &el_size);
 		if (i == index)
 			break;

--- a/src/img4.h
+++ b/src/img4.h
@@ -32,4 +32,4 @@ int img4_stitch_component(const char* component_name, const unsigned char* compo
 }
 #endif
 
-#endif /* idevicerestore_img4_h */
+#endif


### PR DESCRIPTION
At least for me (iPhone 5s), this commit causes the restore to get stuck at "Waiting for device...". Reverting it fixes the issue, and it still compiles on Linux without it.